### PR TITLE
Fix error when trying to change or break a sign

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/listeners/GeneralListener.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/listeners/GeneralListener.java
@@ -221,7 +221,7 @@ public class GeneralListener extends STBBaseListener {
     public void onSignChange(SignChangeEvent event) {
         if (Tag.WALL_SIGNS.isTagged(event.getBlock().getType())) {
             Block b = event.getBlock();
-            WallSign sign = (WallSign) b.getState().getData();
+            WallSign sign = (WallSign) b.getBlockData();
 
             Block attachedTo = b.getRelative(sign.getFacing());
             BaseSTBBlock item = LocationManager.getManager().get(attachedTo.getLocation());
@@ -243,7 +243,7 @@ public class GeneralListener extends STBBaseListener {
     @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
     public void onLabelSignBroken(BlockBreakEvent event) {
         if (Tag.WALL_SIGNS.isTagged(event.getBlock().getType())) {
-            WallSign sign = (WallSign) event.getBlock().getState().getData();
+            WallSign sign = (WallSign) event.getBlock().getBlockData();
             Block b2 = event.getBlock().getRelative(sign.getFacing());
             BaseSTBBlock stb = LocationManager.getManager().get(b2.getLocation());
 


### PR DESCRIPTION
Fixes #10

## Description
Fix class cast exception when trying to change or break a sign

## Changes
Switched to `getBlockData` inside the sign event handlers.

## Related Issues
Resolves #10 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
