### PR TITLE
Fixed onLabelSignBroken method - Previously wasn't removing

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/listeners/GeneralListener.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/listeners/GeneralListener.java
@@ -244,11 +244,11 @@ public class GeneralListener extends STBBaseListener {
     public void onLabelSignBroken(BlockBreakEvent event) {
         if (Tag.WALL_SIGNS.isTagged(event.getBlock().getType())) {
             WallSign sign = (WallSign) event.getBlock().getBlockData();
-            Block b2 = event.getBlock().getRelative(sign.getFacing());
+            Block b2 = event.getBlock().getRelative(sign.getFacing().getOppositeFace());
             BaseSTBBlock stb = LocationManager.getManager().get(b2.getLocation());
 
             if (stb != null) {
-                stb.detachLabelSign(sign.getFacing().getOppositeFace());
+                stb.detachLabelSign(sign.getFacing());
             }
         }
     }


### PR DESCRIPTION
The facing direction and the opposite facing direction were being used in the wrong place

## Description
I changed the two BlockFace directions used in the onLabelSignBroken method as they were the wrong way round. getFacing was being used to get the attached block and the opposite of get facing was being used to get the direction from the block to the sign.

## Changes
<!-- Please list all the changes you have made. -->
Changed the block from getRelative(sign.getFacing()) to getRelative(sign.getFacing().getOppositeFace())
Changed the face passed to the detachLabelSign method to sign.getFacing()

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
