### PR TITLE
Bug/sign types

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBBlock.java
@@ -568,6 +568,7 @@ public abstract class BaseSTBBlock extends BaseSTBItem {
             SensibleToolboxPlugin.getInstance().getEnergyNetManager().onMachinePlaced((ChargeableBlock) this);
         }
 
+        // This gets the type of the sign to move and also guards against duplicate event firing (Piston bug)
         HashMap<Integer, Material> signTypes = new HashMap<>();
 
         Bukkit.getScheduler().runTask(SensibleToolboxPlugin.getInstance(), () -> {

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBBlock.java
@@ -1003,8 +1003,11 @@ public abstract class BaseSTBBlock extends BaseSTBItem {
         return true;
     }
 
-    private boolean placeLabelSign(Block signBlock, BlockFace face, @Nonnull Material signType) {
-        Validate.notNull(signType);
+    private boolean placeLabelSign(@Nonnull Block signBlock, @Nonnull BlockFace face, @Nonnull Material signType) {
+        Validate.notNull(signBlock, "The Sign Block cannot be null");
+        Validate.notNull(face, "The Face cannot be null");
+        Validate.notNull(signType, "The Sign Type cannot be null");
+
         if (!signBlock.isEmpty() && !Tag.WALL_SIGNS.isTagged(signBlock.getType())) {
             // something in the way!
             Debugger.getInstance().debug(this + ": can't place label sign @ " + signBlock + ", face = " + face);

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBBlock.java
@@ -1,10 +1,12 @@
 package io.github.thebusybiscuit.sensibletoolbox.api.items;
 
-import it.unimi.dsi.fastutil.Hash;
 import java.util.BitSet;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.UUID;
 
+import javax.annotation.Nonnull;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -46,7 +48,6 @@ import io.github.thebusybiscuit.sensibletoolbox.util.STBUtil;
 import io.github.thebusybiscuit.sensibletoolbox.util.UnicodeSymbol;
 import me.desht.dhutils.Debugger;
 import me.desht.dhutils.PersistableLocation;
-import sun.security.util.Debug;
 
 /**
  * Represents an STB block; an STB item which can be placed as a block in the
@@ -569,7 +570,7 @@ public abstract class BaseSTBBlock extends BaseSTBItem {
         }
 
         // This gets the type of the sign to move and also guards against duplicate event firing (Piston bug)
-        HashMap<Integer, Material> signTypes = new HashMap<>();
+        Map<Integer, Material> signTypes = new HashMap<>();
 
         Bukkit.getScheduler().runTask(SensibleToolboxPlugin.getInstance(), () -> {
             Block b = oldLoc.getBlock();
@@ -588,16 +589,17 @@ public abstract class BaseSTBBlock extends BaseSTBItem {
 
         Bukkit.getScheduler().runTaskLater(SensibleToolboxPlugin.getInstance(), () -> {
             Block b = newLoc.getBlock();
-            signTypes.forEach((rotation,type) -> {
+            for (Entry<Integer, Material> entry: signTypes.entrySet()) {
+                int rotation = entry.getKey();
                 if (labelSigns.get(rotation)) {
                     BlockFace face = STBUtil.getRotatedFace(getFacing(), rotation);
                     Block signBlock = b.getRelative(face);
 
-                    if(!placeLabelSign(signBlock, face, signTypes.get(rotation))){
+                    if(!placeLabelSign(signBlock, face, entry.getValue())){
                         labelSigns.set(rotation, false);
                     }
                 }
-            });
+            }
         }, 2L);
     }
 
@@ -1001,7 +1003,8 @@ public abstract class BaseSTBBlock extends BaseSTBItem {
         return true;
     }
 
-    private boolean placeLabelSign(Block signBlock, BlockFace face, Material signType) {
+    private boolean placeLabelSign(Block signBlock, BlockFace face, @Nonnull Material signType) {
+        Validate.notNull(signType);
         if (!signBlock.isEmpty() && !Tag.WALL_SIGNS.isTagged(signBlock.getType())) {
             // something in the way!
             Debugger.getInstance().debug(this + ": can't place label sign @ " + signBlock + ", face = " + face);

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/util/STBUtil.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/util/STBUtil.java
@@ -724,6 +724,13 @@ public final class STBUtil {
         return false;
     }
 
+    /**
+     * Get the wall sign version of the sign material e.g. OAK_SIGN -> OAK_WALL_SIGN
+     *
+     * @param signType
+     *                 The material of the sign
+     * @return The wall sign version of that sign
+     */
     @Nullable
     public static Material getWallSign(@Nonnull Material signType) {
         switch (signType) {

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/util/STBUtil.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/util/STBUtil.java
@@ -739,7 +739,7 @@ public final class STBUtil {
      */
     @Nullable
     public static Material getWallSign(@Nonnull Material signType) {
-        Validate.notNull(signType);
+        Validate.notNull(signType, "The Sign Type cannot be null");
         if(minecraftVersion >= 16){
             if(signType==Material.CRIMSON_SIGN) return Material.CRIMSON_WALL_SIGN;
             else if(signType==Material.WARPED_SIGN) return Material.WARPED_WALL_SIGN;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/util/STBUtil.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/util/STBUtil.java
@@ -44,6 +44,12 @@ public final class STBUtil {
     private STBUtil() {}
 
     /**
+     * The version of minecraft the server is running (The second number e.g. 1.16.2 gives 16)
+     */
+    public static final int minecraftVersion = Integer.parseInt(
+        SensibleToolboxPlugin.getInstance().getServer().getClass().getPackage().getName().replace(".",",").split(",")[3].substring(1).split("_")[1]);
+
+    /**
      * The block faces directly adjacent to a block.
      */
     public static final BlockFace[] directFaces = { BlockFace.UP, BlockFace.NORTH, BlockFace.EAST, BlockFace.DOWN, BlockFace.SOUTH, BlockFace.WEST };
@@ -733,6 +739,11 @@ public final class STBUtil {
      */
     @Nullable
     public static Material getWallSign(@Nonnull Material signType) {
+        Validate.notNull(signType);
+        if(minecraftVersion >= 16){
+            if(signType==Material.CRIMSON_SIGN) return Material.CRIMSON_WALL_SIGN;
+            else if(signType==Material.WARPED_SIGN) return Material.WARPED_WALL_SIGN;
+        }
         switch (signType) {
             case OAK_SIGN:
                 return Material.OAK_WALL_SIGN;
@@ -746,10 +757,6 @@ public final class STBUtil {
                 return Material.ACACIA_WALL_SIGN;
             case DARK_OAK_SIGN:
                 return Material.DARK_OAK_WALL_SIGN;
-            case CRIMSON_SIGN:
-                return Material.CRIMSON_WALL_SIGN;
-            case WARPED_SIGN:
-                return Material.WARPED_WALL_SIGN;
             default:
                 return null;
         }

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/util/STBUtil.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/util/STBUtil.java
@@ -723,4 +723,28 @@ public final class STBUtil {
         // TODO Fix Potion Ingredient lookup
         return false;
     }
+
+    @Nullable
+    public static Material getWallSign(@Nonnull Material signType) {
+        switch (signType) {
+            case OAK_SIGN:
+                return Material.OAK_WALL_SIGN;
+            case SPRUCE_SIGN:
+                return Material.SPRUCE_WALL_SIGN;
+            case BIRCH_SIGN:
+                return Material.BIRCH_WALL_SIGN;
+            case JUNGLE_SIGN:
+                return Material.JUNGLE_WALL_SIGN;
+            case ACACIA_SIGN:
+                return Material.ACACIA_WALL_SIGN;
+            case DARK_OAK_SIGN:
+                return Material.DARK_OAK_WALL_SIGN;
+            case CRIMSON_SIGN:
+                return Material.CRIMSON_WALL_SIGN;
+            case WARPED_SIGN:
+                return Material.WARPED_WALL_SIGN;
+            default:
+                return null;
+        }
+    }
 }


### PR DESCRIPTION
Modified methods that create label signs and created a util method to get the wall sign from the material of the sign.

## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
To add support for all types of signs, placeLabelSign now takes a Material signType as another parameter to specify the type of the sign to palce.

attachLabelSign gets this type from the type of the sign in the players hand, using the util method getWallSign()

reattachLabelSign attempts to get the sign from the existing block data, if there is none it defaults to Oak.

moveTo gets the sign types from the old block and passes them into a scheduled task to then set them as before. This method also prevents extra processing from the piston bug causing piston events to fire multiple times.

## Changes
<!-- Please list all the changes you have made. -->

- Created the getWallSign util method in STBUtil.
- Changed palceLabelSign to take an extra parameter signType to specify the type of the sign to add.
- Changed the section of moveTo that deals with Label signs to support the new signType parameter.
- Changed reattachLabelSigns to support the new signType parameter.
- Changed the attachLabelSign to get the type of the sign from the players hand and support the new parameter.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #12

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behavior for null values
