### PR TITLE
Basic fixes to Infernalfarm

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/InfernalFarm.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/InfernalFarm.java
@@ -60,6 +60,20 @@ public class InfernalFarm extends AutoFarm {
         res.setIngredient('N', Material.NETHER_BRICK);
         return res;
     }
+    
+    @Override
+    public void onBlockRegistered(Location location, boolean isPlacing) {
+        int range = RADIUS / 2;
+        Block block = location.getBlock();
+
+        for (int x = -range; x <= range; x++) {
+            for (int z = -range; z <= range; z++) {
+                blocks.add(block.getRelative(x, 2, z));
+            }
+        }
+
+        super.onBlockRegistered(location, isPlacing);
+    }
 
     @Override
     public void onServerTick() {
@@ -71,9 +85,9 @@ public class InfernalFarm extends AutoFarm {
 
                         if (ageable.getAge() >= ageable.getMaximumAge()) {
                             setCharge(getCharge() - getScuPerCycle());
-
                             ageable.setAge(0);
                             crop.getWorld().playEffect(crop.getLocation(), Effect.STEP_SOUND, crop.getType());
+                            crop.setBlockData(ageable);
                             setJammed(!output(Material.NETHER_WART));
                             break;
                         }


### PR DESCRIPTION
## Description
Fixed infernalfarm so it would actually work - harvest, replant nether wart.


## Changes
Added a check for blocks in 5 block radius 2 blocks above the machine for nether wart and fixed harvesting not resseting the age of the plant to 0.

## Related Issues
None

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [+] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [+] I followed the existing code standards and didn't mess up the formatting.
- [-] I did my best to add documentation to any public classes or methods I added.
- [-] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
