### PR TITLE
Fixes AutoBuilder block placement

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoBuilder.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoBuilder.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.sensibletoolbox.blocks.machines;
 
 import javax.annotation.Nonnull;
 
+import me.desht.dhutils.text.LogUtils;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -214,10 +215,10 @@ public class AutoBuilder extends BaseSTBMachine {
             buildZ = workArea.getLowerZ();
         }
 
-        if (getBuildMode() != AutoBuilderMode.CLEAR && initInventoryPointer()) {
-            setStatus(BuilderStatus.NO_INVENTORY);
-        } else {
+        if (getBuildMode() == AutoBuilderMode.CLEAR || initInventoryPointer()) {
             setStatus(BuilderStatus.RUNNING);
+        } else {
+            setStatus(BuilderStatus.NO_INVENTORY);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoBuilder.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoBuilder.java
@@ -2,7 +2,6 @@ package io.github.thebusybiscuit.sensibletoolbox.blocks.machines;
 
 import javax.annotation.Nonnull;
 
-import me.desht.dhutils.text.LogUtils;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;


### PR DESCRIPTION
## Description
Fixed the AutoBuilder not being able to... build. The AutoBuilder has not been able to build for some time and it is an advertised feature of the machine.

## Changes
AutoBuilder#startup was checking the internal inventory but was handling the return boolean incorrectly. I inverted this and the result was the builder working correctly. After this I then reversed the whole if statement as it read much better with two positive questions as opposed to two not checks.

## Related Issues
Resolves #61 

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
