### PR TITLE
Added Angelic Block height limiter

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/AngelicBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/AngelicBlock.java
@@ -24,6 +24,8 @@ import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBBlock;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
 
+import javax.annotation.Nonnull;
+
 public class AngelicBlock extends BaseSTBBlock {
 
     public AngelicBlock() {}

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/AngelicBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/AngelicBlock.java
@@ -83,7 +83,7 @@ public class AngelicBlock extends BaseSTBBlock {
         event.setCancelled(true);
     }
 
-    private boolean isWithinWorldBounds(Block b) {
+    private boolean isWithinWorldBounds(@Nonnull Block b) {
         Location loc = b.getLocation();
         int minHeight;
         if (SensibleToolboxPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_16)) {

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/AngelicBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/AngelicBlock.java
@@ -1,5 +1,7 @@
 package io.github.thebusybiscuit.sensibletoolbox.blocks;
 
+import io.github.thebusybiscuit.sensibletoolbox.SensibleToolboxPlugin;
+import io.github.thebusybiscuit.sensibletoolbox.api.MinecraftVersion;
 import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Location;
@@ -83,7 +85,13 @@ public class AngelicBlock extends BaseSTBBlock {
 
     private boolean isWithinWorldBounds(Block b) {
         Location loc = b.getLocation();
-        return loc.getY() > loc.getWorld().getMinHeight() && loc.getY() < loc.getWorld().getMaxHeight();
+        int minHeight;
+        if (SensibleToolboxPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_16)) {
+            minHeight = loc.getWorld().getMinHeight();
+        } else {
+            minHeight = 0;
+        }
+        return loc.getY() > minHeight && loc.getY() < loc.getWorld().getMaxHeight();
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/AngelicBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/AngelicBlock.java
@@ -64,7 +64,7 @@ public class AngelicBlock extends BaseSTBBlock {
             Location loc = p.getEyeLocation().add(v);
             Block b = loc.getBlock();
 
-            if (b.isEmpty() && SensibleToolbox.getProtectionManager().hasPermission(p, b, ProtectableAction.PLACE_BLOCK)) {
+            if (b.isEmpty() && SensibleToolbox.getProtectionManager().hasPermission(p, b, ProtectableAction.PLACE_BLOCK) && isWithinWorldBounds(b)) {
                 ItemStack stack = event.getItem();
 
                 if (stack.getAmount() > 1) {
@@ -79,6 +79,11 @@ public class AngelicBlock extends BaseSTBBlock {
         }
 
         event.setCancelled(true);
+    }
+
+    private boolean isWithinWorldBounds(Block b) {
+        Location loc = b.getLocation();
+        return loc.getY() > loc.getWorld().getMinHeight() && loc.getY() < loc.getWorld().getMaxHeight();
     }
 
     @Override


### PR DESCRIPTION
## Description
Added height limits to the Angelic Block's placement. Previously blocks were 'placable' outside of world bounds. While the block wouldn't actually appear, the placement would be remembered and particles would continue to spawn without a way for server owners to remove without directly editing config.

## Changes
Added a check for the world height before the block placement is attempted.

## Related Issues


## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
