### PR TITLE
Stopped 'Slimefun' Infernal Dust dropping

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/slimefun/SlimefunBridge.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/slimefun/SlimefunBridge.java
@@ -31,8 +31,6 @@ import me.mrCookieSlime.Slimefun.cscorelib2.recipes.MinecraftRecipe;
 
 public final class SlimefunBridge implements SlimefunAddon {
 
-    public static final RecipeType RECIPE_TYPE_MOB_DROP = new RecipeType(new NamespacedKey(SensibleToolboxPlugin.getInstance(), "mob_drop"), new CustomItem(Material.IRON_SWORD, "&bMob Drop", "&7Kill that Mob to", "&7obtain this Item"));
-
     private final SensibleToolboxPlugin plugin;
 
     public SlimefunBridge(@Nonnull SensibleToolboxPlugin plugin) {
@@ -121,8 +119,9 @@ public final class SlimefunBridge implements SlimefunAddon {
 
         RecipeType masher = new RecipeType(new NamespacedKey(plugin, "masher"), SlimefunItem.getByID("STB_MASHER").getItem());
         RecipeType fermenter = new RecipeType(new NamespacedKey(plugin, "fermenter"), SlimefunItem.getByID("STB_FERMENTER").getItem());
+        RecipeType mobDrop = new RecipeType(new NamespacedKey(plugin, "mob_drop"), new CustomItem(Material.IRON_SWORD, "&bMob Drop", "&7Kill that Mob to", "&7obtain this Item"));
 
-        patch("STB_INFERNALDUST", RECIPE_TYPE_MOB_DROP, new CustomItem(Material.BLAZE_SPAWN_EGG, "&a&oBlaze"));
+        patch("STB_INFERNALDUST", mobDrop, new CustomItem(Material.BLAZE_SPAWN_EGG, "&a&oBlaze"));
         patch("STB_ENERGIZEDGOLDINGOT", new RecipeType(MinecraftRecipe.FURNACE), SlimefunItem.getByID("STB_ENERGIZEDGOLDDUST").getItem());
         patch("STB_QUARTZDUST", masher, new ItemStack(Material.QUARTZ));
         patch("STB_ENERGIZEDIRONINGOT", new RecipeType(MinecraftRecipe.FURNACE), SlimefunItem.getByID("STB_ENERGIZEDIRONDUST").getItem());

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/slimefun/SlimefunBridge.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/slimefun/SlimefunBridge.java
@@ -31,6 +31,8 @@ import me.mrCookieSlime.Slimefun.cscorelib2.recipes.MinecraftRecipe;
 
 public final class SlimefunBridge implements SlimefunAddon {
 
+    public static final RecipeType RECIPE_TYPE_MOB_DROP = new RecipeType(new NamespacedKey(SensibleToolboxPlugin.getInstance(), "mob_drop"), new CustomItem(Material.IRON_SWORD, "&bMob Drop", "&7Kill that Mob to", "&7obtain this Item"));
+
     private final SensibleToolboxPlugin plugin;
 
     public SlimefunBridge(@Nonnull SensibleToolboxPlugin plugin) {
@@ -120,7 +122,7 @@ public final class SlimefunBridge implements SlimefunAddon {
         RecipeType masher = new RecipeType(new NamespacedKey(plugin, "masher"), SlimefunItem.getByID("STB_MASHER").getItem());
         RecipeType fermenter = new RecipeType(new NamespacedKey(plugin, "fermenter"), SlimefunItem.getByID("STB_FERMENTER").getItem());
 
-        patch("STB_INFERNALDUST", RecipeType.MOB_DROP, new CustomItem(Material.BLAZE_SPAWN_EGG, "&a&oBlaze"));
+        patch("STB_INFERNALDUST", RECIPE_TYPE_MOB_DROP, new CustomItem(Material.BLAZE_SPAWN_EGG, "&a&oBlaze"));
         patch("STB_ENERGIZEDGOLDINGOT", new RecipeType(MinecraftRecipe.FURNACE), SlimefunItem.getByID("STB_ENERGIZEDGOLDDUST").getItem());
         patch("STB_QUARTZDUST", masher, new ItemStack(Material.QUARTZ));
         patch("STB_ENERGIZEDIRONINGOT", new RecipeType(MinecraftRecipe.FURNACE), SlimefunItem.getByID("STB_ENERGIZEDIRONDUST").getItem());


### PR DESCRIPTION
## Description
Infernal Dust drops two different stack types, one from STB's Drop and another from the MobDrop recipe type in Slimefun. The Slimefun drop includes Slimefun data making the two items not stack. This also inflates the drop rate beyond what is intended within STB.

## Changes
Created a new 'dummy' recipe type to look the same as Slimefun's MobDrop recipe type for display on the guide without triggering Slimefun's drops.

## Related Issues
Resolves #74

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
