### PR TITLE
Fixed vanilla items smelting from STB recipes

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/listeners/FurnaceListener.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/listeners/FurnaceListener.java
@@ -125,13 +125,17 @@ public class FurnaceListener extends STBBaseListener {
             while (recipes.hasNext()) {
                 Recipe recipe = recipes.next();
 
-                if (recipe instanceof FurnaceRecipe && ((FurnaceRecipe) recipe).getInputChoice().test(stack)) {
+                if (recipe instanceof FurnaceRecipe && vanillaRecipeCheck((FurnaceRecipe) recipe, stack)) {
                     return true;
                 }
             }
 
             return false;
         }
+    }
+
+    private boolean vanillaRecipeCheck(FurnaceRecipe recipe, ItemStack stack) {
+        return recipe.getInputChoice().test(stack) && !recipe.getKey().getNamespace().equals("sensibletoolbox");
     }
 
     private int findNewSlot(InventoryClickEvent event) {

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/listeners/FurnaceListener.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/listeners/FurnaceListener.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.sensibletoolbox.listeners;
 
 import java.util.Iterator;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.bukkit.Bukkit;
@@ -134,7 +135,7 @@ public class FurnaceListener extends STBBaseListener {
         }
     }
 
-    private boolean vanillaRecipeCheck(FurnaceRecipe recipe, ItemStack stack) {
+    private boolean vanillaRecipeCheck(@Nonnull FurnaceRecipe recipe, @Nonnull ItemStack stack) {
         return recipe.getInputChoice().test(stack) && !recipe.getKey().getNamespace().equals("sensibletoolbox");
     }
 


### PR DESCRIPTION
## Description
Gunpowder and Glowstone could be smelted into Iron and Gold using a regular furnace. I have fixed this.

## Changes
I am checking the recipe key to see if it was added by STB and, if so, any vanilla input is then rejected. Tested smelting the STB dusts (ok), Smelting vanilla ores (ok) and then gunpowder and glowstone (cancelled as expected)

## Related Issues
Resolves #73

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
