### PR TITLE
Fix Recipe book dupe(s) and Block break dupes

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBMachine.java
@@ -584,6 +584,13 @@ public abstract class BaseSTBMachine extends BaseSTBBlock implements ChargeableB
 
     @Override
     public void onBlockUnregistered(Location loc) {
+
+        // Machines broken while viewed allow items to be taken out.
+        // We need to close the inventories if opened.
+        for (HumanEntity h : getGUI().getViewers()) {
+            h.closeInventory();
+        }
+
         getGUI().ejectItems(getInputSlots());
         getGUI().ejectItems(getOutputSlots());
         getGUI().ejectItems(getUpgradeSlots());

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/gui/STBInventoryGUI.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/gui/STBInventoryGUI.java
@@ -197,10 +197,12 @@ public class STBInventoryGUI implements InventoryGUI {
                 monitor.doRepaint();
             }
         }
-        Debugger.getInstance().debug(player.getName() + " opened GUI for " + getOwningItem());
-        setOpenGUI(player, this);
-        listener.onGUIOpened(player);
-        player.openInventory(inventory);
+        if (getOpenGUI(player) == null) {
+            Debugger.getInstance().debug(player.getName() + " opened GUI for " + getOwningItem());
+            setOpenGUI(player, this);
+            listener.onGUIOpened(player);
+            player.openInventory(inventory);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description
STB Recipe books will allow users to remove items if opened twice fast enough (autoclicker makes this trivial) allowing for the removal of any STB/Vanilla/other registered recipe item assuming they are on the correct page before attempting. 
STB machines allow their items to be removed if the machine is broken while being viewed either by TNT or a 2nd player.

## Changes
For recipe book dupes, I added a check to see if the player has the inventory opened before allowing the 2nd instance to open. This resolved the dupe and has no noticable side effects on machine GUIs.
For the machines I added a check for viewing players and kick them out.

## Related Issues
Don't think these have ever been reported weirdly!

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
