### PR TITLE
Fixed removing EChests from Tuner and Tuner opening in other GUIs

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/EnderTuner.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/EnderTuner.java
@@ -9,6 +9,7 @@ import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
@@ -80,16 +81,18 @@ public class EnderTuner extends BaseSTBItem {
 
     @Override
     public void onInteractItem(PlayerInteractEvent event) {
-        Block clicked = event.getClickedBlock();
-        BaseSTBBlock stb = clicked == null ? null : SensibleToolbox.getBlockAt(clicked.getLocation(), true);
+        if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+            Block clicked = event.getClickedBlock();
+            BaseSTBBlock stb = clicked == null ? null : SensibleToolbox.getBlockAt(clicked.getLocation(), true);
 
-        if (stb instanceof EnderTunable && stb.hasAccessRights(event.getPlayer())) {
-            tuningBlock = (EnderTunable) stb;
+            if (stb instanceof EnderTunable && stb.hasAccessRights(event.getPlayer())) {
+                tuningBlock = (EnderTunable) stb;
+            }
+
+            inventoryGUI = makeTuningGUI(event.getPlayer());
+            inventoryGUI.show(event.getPlayer());
+            event.setCancelled(true);
         }
-
-        inventoryGUI = makeTuningGUI(event.getPlayer());
-        inventoryGUI.show(event.getPlayer());
-        event.setCancelled(true);
     }
 
     @Nonnull
@@ -211,9 +214,8 @@ public class EnderTuner extends BaseSTBItem {
         if (tuningBlock != null) {
             if (player instanceof Player) {
                 STBUtil.complain((Player) player);
-            } else {
-                return false;
             }
+            return false;
         }
 
         if (slot == TUNED_ITEM_SLOT && inventoryGUI.getItem(slot) != null) {


### PR DESCRIPTION
## Description
Placed Ender Boxes can be pulled out from the tuner GUI without any effort.
Found while testing this issue, the Ender Tiner will overide interactions in other GUI's (like /sf open_guide)

## Changes
Fixed the return when tuningblock != null in EnderTuner#onShiftClickExtract. 
Wrapped onInteractEvent with an action check.

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
