### PR TITLE
Make Slimefun blocks unable to be replaced

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/SensibleToolboxPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/SensibleToolboxPlugin.java
@@ -172,6 +172,7 @@ public class SensibleToolboxPlugin extends JavaPlugin implements ConfigurationLi
     private MinecraftVersion minecraftVersion = MinecraftVersion.UNKNOWN;
 
     private ConfigurationManager configManager;
+    private boolean slimefunEnabled = false;
     private boolean protocolLibEnabled = false;
     private SoundMufflerListener soundMufflerListener;
     private boolean enabled = false;
@@ -483,6 +484,10 @@ public class SensibleToolboxPlugin extends JavaPlugin implements ConfigurationLi
             LogUtils.warning("ProtocolLib not detected - some functionality is reduced:");
             LogUtils.warning("  No glowing items, Reduced particle effects, Sound Muffler item disabled");
         }
+    }
+
+    public boolean isSlimefunEnabled() {
+        return slimefunEnabled;
     }
 
     public boolean isProtocolLibEnabled() {

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/SensibleToolboxPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/SensibleToolboxPlugin.java
@@ -259,6 +259,7 @@ public class SensibleToolboxPlugin extends JavaPlugin implements ConfigurationLi
         scheduleEnergyNetTicker();
 
         if (getServer().getPluginManager().isPluginEnabled("Slimefun")) {
+            slimefunEnabled = true;
             new SlimefunBridge(this);
         }
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/multibuilder/MultiBuilder.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/multibuilder/MultiBuilder.java
@@ -30,8 +30,10 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
+import io.github.thebusybiscuit.sensibletoolbox.SensibleToolboxPlugin;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.energy.Chargeable;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBItem;
@@ -253,14 +255,21 @@ public class MultiBuilder extends BaseSTBItem implements Chargeable {
     }
 
     protected boolean canReplace(Player player, Block b) {
-        // we won't replace any block which can hold items, or any STB block, or any unbreakable block
+        // Check for non-replaceable block types.
+        // STB Blocks
         if (SensibleToolbox.getBlockAt(b.getLocation(), true) != null) {
             return false;
+        // Vanilla inventories
         } else if (VanillaInventoryUtils.isVanillaInventory(b)) {
             return false;
+        // Slimefun Blocks
+        } else if (SensibleToolboxPlugin.getInstance().isSlimefunEnabled() && BlockStorage.hasBlockInfo(b)) {
+            return false;
+        // Unbreakable Blocks
         } else if (b.getType().getHardness() >= 3600000) {
             return false;
         } else {
+            // Block is replaceable, return permission to break
             return SensibleToolbox.getProtectionManager().hasPermission(player, b, ProtectableAction.BREAK_BLOCK);
         }
     }


### PR DESCRIPTION
## Description
The Multibuilder, in SWAP mode, could swap the material of Slimefun blocks. This allows the duping of blocks on a 1 by 1 basis. In the example provided on the Slimefun Discord, the Powered Bedrock block from Infinity Expansion constantly set's it's material back which allowed for a very fast and powerful dupe.

## Changes
Given the potential issues, and that all STB blocks are also exempt from swapping, I have added a Blockstorage check to the canReplace() method should Simefun be present.
Added a isSlimefunEnabled variable and a getter to SensibleToolboxPlugin.java

## Related Issues

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
