### PR TITLE
Update to RC-28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- Spigot properties -->
-        <spigot.version>1.17.1</spigot.version>
+        <spigot.version>1.18.1</spigot.version>
         <spigot.javadocs>https://hub.spigotmc.org/javadocs/spigot/</spigot.javadocs>
 
         <!-- Default settings for sonarcloud.io -->

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,12 @@
     </build>
 
     <dependencies>
+	    <dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.22</version>
+			<scope>provided</scope>
+		</dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -193,12 +193,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>${spigot.version}-R0.1-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -192,12 +192,12 @@
     </build>
 
     <dependencies>
-	    <dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.22</version>
-			<scope>provided</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.22</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- Spigot properties -->
-        <spigot.version>1.17</spigot.version>
+        <spigot.version>1.17.1</spigot.version>
         <spigot.javadocs>https://hub.spigotmc.org/javadocs/spigot/</spigot.javadocs>
 
         <!-- Default settings for sonarcloud.io -->
@@ -67,7 +67,7 @@
         </repository>
         <repository>
             <id>worldedit-repo</id>
-            <url>https://maven.sk89q.com/repo/</url>
+            <url>https://maven.enginehub.org/repo/</url>
         </repository>
     </repositories>
 
@@ -202,12 +202,12 @@
         <dependency>
             <groupId>com.github.TheBusyBiscuit</groupId>
             <artifactId>Slimefun4</artifactId>
-            <version>RC-25</version>
+            <version>RC-27</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>io.github.thebusybiscuit</groupId>
-                    <artifactId>cscorelib2</artifactId>
+                    <groupId>io.github.bakedlibs</groupId>
+                    <artifactId>dough-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -231,13 +231,6 @@
             <artifactId>holographicdisplays-api</artifactId>
             <version>2.4.8</version>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.thebusybiscuit</groupId>
-            <artifactId>CS-CoreLib2</artifactId>
-            <version>0.32.1</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/SensibleToolboxPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/SensibleToolboxPlugin.java
@@ -22,9 +22,6 @@ import org.bukkit.scheduler.BukkitTask;
 
 import com.comphenix.protocol.ProtocolLib;
 
-import io.github.thebusybiscuit.cscorelib2.protection.ProtectionManager;
-import io.github.thebusybiscuit.cscorelib2.updater.GitHubBuildsUpdater;
-import io.github.thebusybiscuit.cscorelib2.updater.Updater;
 import io.github.thebusybiscuit.sensibletoolbox.api.AccessControl;
 import io.github.thebusybiscuit.sensibletoolbox.api.FriendManager;
 import io.github.thebusybiscuit.sensibletoolbox.api.MinecraftVersion;
@@ -154,6 +151,10 @@ import io.github.thebusybiscuit.sensibletoolbox.listeners.WorldListener;
 import io.github.thebusybiscuit.sensibletoolbox.slimefun.SlimefunBridge;
 import io.github.thebusybiscuit.sensibletoolbox.utils.ItemGlow;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.ProtectionManager;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.updater.GitHubBuildsUpdater;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.updater.PluginUpdater;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.versions.PrefixedVersion;
 import io.papermc.lib.PaperLib;
 
 import me.desht.dhutils.DHUtilsException;
@@ -264,7 +265,7 @@ public class SensibleToolboxPlugin extends JavaPlugin implements ConfigurationLi
         }
 
         if (getConfig().getBoolean("options.auto-update") && getDescription().getVersion().startsWith("DEV - ")) {
-            Updater updater = new GitHubBuildsUpdater(this, getFile(), "Slimefun/SensibleToolbox/master");
+            PluginUpdater<PrefixedVersion> updater = new GitHubBuildsUpdater(this, getFile(), "Slimefun/SensibleToolbox/master");
             updater.start();
         }
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/MinecraftVersion.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/MinecraftVersion.java
@@ -49,7 +49,7 @@ public enum MinecraftVersion {
      * (The "Caves and Cliffs: Part II" Update)
      *
      */
-    MINECRAFT_1_18(17, "1.18.x"),
+    MINECRAFT_1_18(18, "1.18.x"),
 
     /**
      * This constant represents an exceptional state in which we were unable

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/MinecraftVersion.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/MinecraftVersion.java
@@ -43,6 +43,13 @@ public enum MinecraftVersion {
      *
      */
     MINECRAFT_1_17(17, "1.17.x"),
+    
+    /**
+     * This constant represents Minecraft (Java Edition) Version 1.18
+     * (The "Caves and Cliffs: Part II" Update)
+     *
+     */
+    MINECRAFT_1_18(17, "1.18.x"),
 
     /**
      * This constant represents an exceptional state in which we were unable

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/SensibleToolbox.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/SensibleToolbox.java
@@ -4,11 +4,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 
-import io.github.thebusybiscuit.cscorelib2.protection.ProtectionManager;
 import io.github.thebusybiscuit.sensibletoolbox.SensibleToolboxPlugin;
 import io.github.thebusybiscuit.sensibletoolbox.api.energy.EnergyNet;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBBlock;
 import io.github.thebusybiscuit.sensibletoolbox.core.storage.LocationManager;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.ProtectionManager;
 
 /**
  * Top-level collection of utility methods for Sensible Toolbox.

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBItem.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBItem.java
@@ -34,7 +34,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.permissions.Permissible;
 import org.bukkit.plugin.Plugin;
 
-import io.github.thebusybiscuit.cscorelib2.data.PersistentDataAPI;
 import io.github.thebusybiscuit.sensibletoolbox.SensibleToolboxPlugin;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.energy.Chargeable;
@@ -42,6 +41,7 @@ import io.github.thebusybiscuit.sensibletoolbox.api.gui.InventoryGUIListener;
 import io.github.thebusybiscuit.sensibletoolbox.core.STBItemRegistry;
 import io.github.thebusybiscuit.sensibletoolbox.utils.ItemGlow;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 
 /**
  * Represents an STB item. This is the superclass for all STB items.

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/AngelicBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/AngelicBlock.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.sensibletoolbox.blocks;
 
 import io.github.thebusybiscuit.sensibletoolbox.SensibleToolboxPlugin;
 import io.github.thebusybiscuit.sensibletoolbox.api.MinecraftVersion;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Location;
@@ -19,7 +20,6 @@ import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.util.Vector;
 
-import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBBlock;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
@@ -68,7 +68,7 @@ public class AngelicBlock extends BaseSTBBlock {
             Location loc = p.getEyeLocation().add(v);
             Block b = loc.getBlock();
 
-            if (b.isEmpty() && SensibleToolbox.getProtectionManager().hasPermission(p, b, ProtectableAction.PLACE_BLOCK) && isWithinWorldBounds(b)) {
+            if (b.isEmpty() && SensibleToolbox.getProtectionManager().hasPermission(p, b, Interaction.PLACE_BLOCK) && isWithinWorldBounds(b)) {
                 ItemStack stack = event.getItem();
 
                 if (stack.getAmount() > 1) {
@@ -102,7 +102,7 @@ public class AngelicBlock extends BaseSTBBlock {
         Player p = event.getPlayer();
         Block b = event.getBlock();
 
-        if (SensibleToolbox.getProtectionManager().hasPermission(p, b, ProtectableAction.BREAK_BLOCK)) {
+        if (SensibleToolbox.getProtectionManager().hasPermission(p, b, Interaction.BREAK_BLOCK)) {
             b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
             breakBlock(false);
             STBUtil.giveItems(p, toItemStack());

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoBuilder.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoBuilder.java
@@ -21,7 +21,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 
-import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.gui.InventoryGUI;
 import io.github.thebusybiscuit.sensibletoolbox.api.gui.SlotType;
@@ -35,6 +34,7 @@ import io.github.thebusybiscuit.sensibletoolbox.items.components.IntegratedCircu
 import io.github.thebusybiscuit.sensibletoolbox.items.components.ToughMachineFrame;
 import io.github.thebusybiscuit.sensibletoolbox.utils.ColoredMaterial;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import me.desht.dhutils.MiscUtil;
 import me.desht.dhutils.cuboid.Cuboid;
 import me.desht.dhutils.cuboid.CuboidDirection;
@@ -264,7 +264,7 @@ public class AutoBuilder extends BaseSTBMachine {
 
             switch (getBuildMode()) {
                 case CLEAR:
-                    if (!SensibleToolbox.getProtectionManager().hasPermission(owner, b, ProtectableAction.BREAK_BLOCK)) {
+                    if (!SensibleToolbox.getProtectionManager().hasPermission(owner, b, Interaction.BREAK_BLOCK)) {
                         setStatus(BuilderStatus.NO_PERMISSION);
                         return;
                     }
@@ -290,7 +290,7 @@ public class AutoBuilder extends BaseSTBMachine {
                 case FILL:
                 case WALLS:
                 case FRAME:
-                    if (!SensibleToolbox.getProtectionManager().hasPermission(owner, b, ProtectableAction.PLACE_BLOCK)) {
+                    if (!SensibleToolbox.getProtectionManager().hasPermission(owner, b, Interaction.PLACE_BLOCK)) {
                         setStatus(BuilderStatus.NO_PERMISSION);
                         return;
                     }

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoFarm.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoFarm.java
@@ -18,10 +18,10 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 
-import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.AutoFarmingMachine;
 import io.github.thebusybiscuit.sensibletoolbox.items.IronCombineHoe;
 import io.github.thebusybiscuit.sensibletoolbox.items.components.MachineFrame;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 
 public class AutoFarm extends AutoFarmingMachine {
 
@@ -133,7 +133,7 @@ public class AutoFarm extends AutoFarmingMachine {
                     amount = (stack.getMaxStackSize() - stack.getAmount()) > 3 ? (ThreadLocalRandom.current().nextInt(2) + 1) : (stack.getMaxStackSize() - stack.getAmount());
                 }
 
-                setInventoryItem(slot, new CustomItem(stack, stack.getAmount() + amount));
+                setInventoryItem(slot, new CustomItemStack(stack, stack.getAmount() + amount));
                 buffer = null;
                 return true;
             }

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoForester.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoForester.java
@@ -19,6 +19,7 @@ import org.bukkit.inventory.ShapedRecipe;
 
 import io.github.thebusybiscuit.sensibletoolbox.api.items.AutoFarmingMachine;
 import io.github.thebusybiscuit.sensibletoolbox.items.components.MachineFrame;
+import io.github.thebusybiscuit.sensibletoolbox.utils.MaterialConverter;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.Vein;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoForester.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoForester.java
@@ -17,11 +17,10 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 
-import io.github.thebusybiscuit.cscorelib2.blocks.Vein;
-import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
-import io.github.thebusybiscuit.cscorelib2.materials.MaterialConverter;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.AutoFarmingMachine;
 import io.github.thebusybiscuit.sensibletoolbox.items.components.MachineFrame;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.Vein;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 
 public class AutoForester extends AutoFarmingMachine {
 
@@ -135,7 +134,7 @@ public class AutoForester extends AutoFarmingMachine {
                     stack = new ItemStack(m);
                 }
 
-                setInventoryItem(slot, new CustomItem(stack, stack.getAmount() + 1));
+                setInventoryItem(slot, new CustomItemStack(stack, stack.getAmount() + 1));
                 buffer = null;
                 return true;
             }

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/BigStorageUnit.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/BigStorageUnit.java
@@ -26,13 +26,13 @@ import org.bukkit.inventory.RecipeChoice.MaterialChoice;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.metadata.FixedMetadataValue;
 
-import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import io.github.thebusybiscuit.sensibletoolbox.api.gui.GUIUtil;
 import io.github.thebusybiscuit.sensibletoolbox.api.gui.InventoryGUI;
 import io.github.thebusybiscuit.sensibletoolbox.api.gui.gadgets.ToggleButton;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.AbstractProcessingMachine;
 import io.github.thebusybiscuit.sensibletoolbox.utils.BukkitSerialization;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.ItemUtils;
 import me.desht.dhutils.Debugger;
 
 public class BigStorageUnit extends AbstractProcessingMachine {

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/HyperStorageUnit.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/HyperStorageUnit.java
@@ -11,8 +11,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 
-import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import io.github.thebusybiscuit.sensibletoolbox.items.components.IntegratedCircuit;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.ItemUtils;
 
 public class HyperStorageUnit extends BigStorageUnit {
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/Pump.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/Pump.java
@@ -14,11 +14,11 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 
-import io.github.thebusybiscuit.cscorelib2.blocks.Vein;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.AbstractProcessingMachine;
 import io.github.thebusybiscuit.sensibletoolbox.items.components.MachineFrame;
 import io.github.thebusybiscuit.sensibletoolbox.items.components.SimpleCircuit;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.Vein;
 
 public class Pump extends AbstractProcessingMachine {
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/Sawmill.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/Sawmill.java
@@ -17,6 +17,7 @@ import io.github.thebusybiscuit.sensibletoolbox.api.recipes.CustomRecipeManager;
 import io.github.thebusybiscuit.sensibletoolbox.api.recipes.SimpleCustomRecipe;
 import io.github.thebusybiscuit.sensibletoolbox.items.components.MachineFrame;
 import io.github.thebusybiscuit.sensibletoolbox.items.components.SimpleCircuit;
+import io.github.thebusybiscuit.sensibletoolbox.utils.MaterialConverter;
 
 public class Sawmill extends AbstractIOMachine {
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/Sawmill.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/Sawmill.java
@@ -11,7 +11,6 @@ import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.RecipeChoice.MaterialChoice;
 import org.bukkit.inventory.ShapedRecipe;
 
-import io.github.thebusybiscuit.cscorelib2.materials.MaterialConverter;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.AbstractIOMachine;
 import io.github.thebusybiscuit.sensibletoolbox.api.recipes.CustomRecipeManager;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/commands/ShowCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/commands/ShowCommand.java
@@ -26,13 +26,13 @@ import org.bukkit.plugin.Plugin;
 
 import com.google.common.base.Joiner;
 
-import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBBlock;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBItem;
 import io.github.thebusybiscuit.sensibletoolbox.core.storage.LocationManager;
 import io.github.thebusybiscuit.sensibletoolbox.utils.BukkitSerialization;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.ItemUtils;
 import me.desht.dhutils.DHUtilsException;
 import me.desht.dhutils.MiscUtil;
 import me.desht.dhutils.commands.AbstractCommand;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/STBItemRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/STBItemRegistry.java
@@ -28,13 +28,13 @@ import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.plugin.Plugin;
 
-import io.github.thebusybiscuit.cscorelib2.data.PersistentDataAPI;
 import io.github.thebusybiscuit.sensibletoolbox.SensibleToolboxPlugin;
 import io.github.thebusybiscuit.sensibletoolbox.api.ItemRegistry;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBBlock;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBItem;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.ItemAction;
 import io.github.thebusybiscuit.sensibletoolbox.core.storage.LocationManager;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 
 public class STBItemRegistry implements ItemRegistry, Keyed {
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/CombineHoe.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/CombineHoe.java
@@ -25,14 +25,14 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 
-import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
-import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.gui.GUIUtil;
 import io.github.thebusybiscuit.sensibletoolbox.api.gui.InventoryGUI;
 import io.github.thebusybiscuit.sensibletoolbox.api.gui.SlotType;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBItem;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.ItemUtils;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import me.desht.dhutils.cuboid.Cuboid;
 import me.desht.dhutils.cuboid.CuboidDirection;
 
@@ -269,7 +269,7 @@ public abstract class CombineHoe extends BaseSTBItem {
         for (Block neighbour : STBUtil.getSurroundingBlocks(b)) {
             Block above = neighbour.getRelative(BlockFace.UP);
 
-            if (!SensibleToolbox.getProtectionManager().hasPermission(player, above, ProtectableAction.PLACE_BLOCK)) {
+            if (!SensibleToolbox.getProtectionManager().hasPermission(player, above, Interaction.PLACE_BLOCK)) {
                 continue;
             }
 
@@ -297,7 +297,7 @@ public abstract class CombineHoe extends BaseSTBItem {
 
         for (Block block : cuboid) {
             if (!block.equals(b) && (STBUtil.isPlant(block.getType()) || Tag.LEAVES.isTagged(block.getType()))) {
-                if (!SensibleToolbox.getProtectionManager().hasPermission(player, b, ProtectableAction.BREAK_BLOCK)) {
+                if (!SensibleToolbox.getProtectionManager().hasPermission(player, b, Interaction.BREAK_BLOCK)) {
                     block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
                     block.breakNaturally();
                 }
@@ -311,7 +311,7 @@ public abstract class CombineHoe extends BaseSTBItem {
         int damage = ((Damageable) stack.getItemMeta()).getDamage();
 
         for (Block b1 : STBUtil.getSurroundingBlocks(b)) {
-            if (!SensibleToolbox.getProtectionManager().hasPermission(player, b1, ProtectableAction.BREAK_BLOCK)) {
+            if (!SensibleToolbox.getProtectionManager().hasPermission(player, b1, Interaction.BREAK_BLOCK)) {
                 continue;
             }
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/PaintBrush.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/PaintBrush.java
@@ -31,8 +31,7 @@ import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.material.Colorable;
 
-import io.github.thebusybiscuit.cscorelib2.inventory.ChestMenu;
-import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBBlock;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBItem;
@@ -41,6 +40,7 @@ import io.github.thebusybiscuit.sensibletoolbox.utils.HoloMessage;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
 import io.github.thebusybiscuit.sensibletoolbox.utils.UnicodeSymbol;
 import me.desht.dhutils.Debugger;
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 
 public class PaintBrush extends BaseSTBItem {
 
@@ -309,13 +309,13 @@ public class PaintBrush extends BaseSTBItem {
         Painting editingPainting = painting;
 
         Art[] other = getOtherArt(painting.getArt());
-        ChestMenu menu = new ChestMenu(getProviderPlugin(), "Select Artwork");
+        ChestMenu menu = new ChestMenu("Select Artwork");
         menu.setEmptySlotsClickable(false);
         menu.setPlayerInventoryClickable(false);
 
         int i = 0;
         for (Art art : other) {
-            menu.addItem(i, new CustomItem(Material.PAINTING, art.name(), "", "&7Click to select this artwork"), (pl, slot, item, cursor, action) -> {
+            menu.addItem(i, new CustomItemStack(Material.PAINTING, art.name(), "", "&7Click to select this artwork"), (pl, slot, item, action) -> {
                 editingPainting.setArt(art);
                 setPaintLevel(getPaintLevel() - art.getBlockWidth() * art.getBlockHeight());
                 updateHeldItemStack(pl, hand);

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/PaintBrush.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/PaintBrush.java
@@ -30,17 +30,19 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.material.Colorable;
-
-import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
+import io.github.thebusybiscuit.sensibletoolbox.api.gui.GUIUtil;
+import io.github.thebusybiscuit.sensibletoolbox.api.gui.InventoryGUI;
+import io.github.thebusybiscuit.sensibletoolbox.api.gui.gadgets.ButtonGadget;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBBlock;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBItem;
 import io.github.thebusybiscuit.sensibletoolbox.blocks.PaintCan;
 import io.github.thebusybiscuit.sensibletoolbox.utils.HoloMessage;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
 import io.github.thebusybiscuit.sensibletoolbox.utils.UnicodeSymbol;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import me.desht.dhutils.Debugger;
-import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 
 public class PaintBrush extends BaseSTBItem {
 
@@ -207,6 +209,9 @@ public class PaintBrush extends BaseSTBItem {
 
     @Override
     public void onInteractEntity(PlayerInteractEntityEvent event) {
+    	if(!event.getHand().equals(EquipmentSlot.HAND)) {
+    		return;
+    	}
         event.setCancelled(true);
 
         if (getPaintLevel() <= 0) {
@@ -262,10 +267,15 @@ public class PaintBrush extends BaseSTBItem {
         find(b.getRelative(BlockFace.DOWN), mat, blocks, max);
     }
 
-    @Nullable
+	@Nullable
     private DyeColor getBlockColor(@Nonnull Block b) {
         if (STBUtil.isColorable(b.getType())) {
-            return DyeColor.getByColor(getColor().getColor());
+        	String name = b.getType().name();
+        	String color = name.split("_")[0];
+			if(color.equals("LIGHT")) {
+				color += "_"+name.split("_")[1];
+			}
+			return DyeColor.valueOf(color);
         } else {
             return null;
         }
@@ -274,34 +284,38 @@ public class PaintBrush extends BaseSTBItem {
     private int paintBlocks(@Nonnull Player player, Block... blocks) {
         int painted = 0;
 
-        // TODO: Get Paint Brush working again
-        // for (Block b : blocks) {
-        // if (!SensibleToolbox.getProtectionManager().hasPermission(player, b, ProtectableAction.PLACE_BLOCK)) {
-        // continue;
-        // }
-        //
-        // Debugger.getInstance().debug(2, "painting! " + b + " " + getPaintLevel() + " " + getColor());
-        // BaseSTBBlock stb = SensibleToolbox.getBlockAt(b.getLocation());
-        //
-        // if (stb instanceof Colorable) {
-        // ((Colorable) stb).setColor(getColor());
-        // }
-        // else {
-        // if (b.getType() == Material.GLASS) {
-        // b.setType(Material.STAINED_GLASS);
-        // }
-        // else if (b.getType() == Material.GLASS_PANE) {
-        // b.setType(Material.STAINED_GLASS_PANE);
-        // }
-        // }
-        //
-        // painted++;
-        // setPaintLevel(getPaintLevel() - 1);
-        //
-        // if (getPaintLevel() <= 0) {
-        // break;
-        // }
-        // }
+		for (Block b : blocks) {
+			if (!SensibleToolbox.getProtectionManager().hasPermission(player, b, Interaction.PLACE_BLOCK)) {
+				continue;
+			}
+
+			Debugger.getInstance().debug(2, "painting! " + b + " " + getPaintLevel() + " " + getColor());
+			
+			if (b.getType() == Material.GLASS) {
+				b.setType(Material.WHITE_STAINED_GLASS);
+			} else if (b.getType() == Material.GLASS_PANE) {
+				b.setType(Material.WHITE_STAINED_GLASS_PANE);
+			} else {
+				if (!STBUtil.isColorable(b.getType())) {
+					continue;
+				}
+
+				String name = b.getType().name();
+				String oldCol = name.split("_")[0];
+				if (oldCol.equals("LIGHT")) {
+					oldCol += "_" + name.split("_")[1];
+				}
+				name = name.replace(oldCol, getColor().name());
+				b.setType(Material.valueOf(name));
+			}
+
+			painted++;
+			setPaintLevel(getPaintLevel() - 1);
+
+			if (getPaintLevel() <= 0) {
+				break;
+			}
+		}
         return painted;
     }
 
@@ -309,25 +323,23 @@ public class PaintBrush extends BaseSTBItem {
         Painting editingPainting = painting;
 
         Art[] other = getOtherArt(painting.getArt());
-        ChestMenu menu = new ChestMenu("Select Artwork");
-        menu.setEmptySlotsClickable(false);
-        menu.setPlayerInventoryClickable(false);
-
+        InventoryGUI menu = GUIUtil.createGUI(p, this,9, ChatColor.DARK_PURPLE + "Select Artwork");
+        
         int i = 0;
         for (Art art : other) {
-            menu.addItem(i, new CustomItemStack(Material.PAINTING, art.name(), "", "&7Click to select this artwork"), (pl, slot, item, action) -> {
-                editingPainting.setArt(art);
-                setPaintLevel(getPaintLevel() - art.getBlockWidth() * art.getBlockHeight());
-                updateHeldItemStack(pl, hand);
-                pl.playSound(editingPainting.getLocation(), Sound.BLOCK_WATER_AMBIENT, 1.0F, 1.5F);
-                pl.closeInventory();
-                return false;
-            });
-
+        	menu.addGadget(new ButtonGadget(menu,i,new CustomItemStack(Material.PAINTING, art.name(), "", "&7Click to select this artwork"),new Runnable() {
+				@Override
+				public void run() {
+					editingPainting.setArt(art);
+	                setPaintLevel(getPaintLevel() - art.getBlockWidth() * art.getBlockHeight());
+	                updateHeldItemStack(p, hand);
+	                p.playSound(editingPainting.getLocation(), Sound.BLOCK_WATER_AMBIENT, 1.0F, 1.5F);
+	                p.closeInventory();
+				}
+        	}));
             i++;
         }
-
-        menu.open(p);
+        menu.show(p);
     }
 
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/WateringCan.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/WateringCan.java
@@ -26,11 +26,11 @@ import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.PotionMeta;
 
-import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBItem;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
 import io.github.thebusybiscuit.sensibletoolbox.utils.SoilSaturation;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import me.desht.dhutils.MiscUtil;
 
 public class WateringCan extends BaseSTBItem {
@@ -259,7 +259,7 @@ public class WateringCan extends BaseSTBItem {
 
     @ParametersAreNonnullByDefault
     private void maybeGrowCrop(Player player, Block b) {
-        if (!STBUtil.isCrop(b.getType()) || !SensibleToolbox.getProtectionManager().hasPermission(player, b, ProtectableAction.PLACE_BLOCK)) {
+        if (!STBUtil.isCrop(b.getType()) || !SensibleToolbox.getProtectionManager().hasPermission(player, b, Interaction.PLACE_BLOCK)) {
             return;
         }
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/BreakerModule.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/BreakerModule.java
@@ -12,8 +12,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapelessRecipe;
 
-import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 
 public class BreakerModule extends DirectionalItemRouterModule {
 
@@ -44,7 +44,7 @@ public class BreakerModule extends DirectionalItemRouterModule {
         ItemStack inBuffer = getItemRouter().getBufferItem();
 
         if (inBuffer == null || inBuffer.isSimilar(mainDrop) && inBuffer.getAmount() < inBuffer.getMaxStackSize()) {
-            if (getFilter().shouldPass(mainDrop) && SensibleToolbox.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(getItemRouter().getOwner()), b, ProtectableAction.BREAK_BLOCK)) {
+            if (getFilter().shouldPass(mainDrop) && SensibleToolbox.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(getItemRouter().getOwner()), b, Interaction.BREAK_BLOCK)) {
                 if (inBuffer == null) {
                     getItemRouter().setBufferItem(mainDrop);
                 } else {

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/DirectionalItemRouterModule.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/DirectionalItemRouterModule.java
@@ -19,7 +19,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.Directional;
 
-import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import io.github.thebusybiscuit.sensibletoolbox.api.STBInventoryHolder;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.filters.Filter;
@@ -35,6 +34,7 @@ import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBBlock;
 import io.github.thebusybiscuit.sensibletoolbox.blocks.router.ItemRouter;
 import io.github.thebusybiscuit.sensibletoolbox.utils.UnicodeSymbol;
 import io.github.thebusybiscuit.sensibletoolbox.utils.VanillaInventoryUtils;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.ItemUtils;
 
 public abstract class DirectionalItemRouterModule extends ItemRouterModule implements Filtering, Directional {
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/multibuilder/MultiBuilder.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/multibuilder/MultiBuilder.java
@@ -31,8 +31,6 @@ import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
-import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
-import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.sensibletoolbox.SensibleToolboxPlugin;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.energy.Chargeable;
@@ -42,6 +40,8 @@ import io.github.thebusybiscuit.sensibletoolbox.items.energycells.TenKEnergyCell
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
 import io.github.thebusybiscuit.sensibletoolbox.utils.UnicodeSymbol;
 import io.github.thebusybiscuit.sensibletoolbox.utils.VanillaInventoryUtils;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.ItemUtils;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import me.desht.dhutils.Debugger;
 import me.desht.dhutils.blocks.BlockAndPosition;
 import me.desht.dhutils.blocks.BlockUtil;
@@ -270,7 +270,7 @@ public class MultiBuilder extends BaseSTBItem implements Chargeable {
             return false;
         } else {
             // Block is replaceable, return permission to break
-            return SensibleToolbox.getProtectionManager().hasPermission(player, b, ProtectableAction.BREAK_BLOCK);
+            return SensibleToolbox.getProtectionManager().hasPermission(player, b, Interaction.BREAK_BLOCK);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/recipebook/RecipeBook.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/recipebook/RecipeBook.java
@@ -42,8 +42,6 @@ import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
-import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.sensibletoolbox.SensibleToolboxPlugin;
 import io.github.thebusybiscuit.sensibletoolbox.api.STBInventoryHolder;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
@@ -64,6 +62,8 @@ import io.github.thebusybiscuit.sensibletoolbox.api.recipes.SimpleCustomRecipe;
 import io.github.thebusybiscuit.sensibletoolbox.core.STBItemRegistry;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
 import io.github.thebusybiscuit.sensibletoolbox.utils.VanillaInventoryUtils;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.ItemUtils;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import me.desht.dhutils.Debugger;
 import me.desht.dhutils.MiscUtil;
 import me.desht.dhutils.cost.ItemCost;
@@ -369,7 +369,7 @@ public class RecipeBook extends BaseSTBItem {
         for (BlockFace face : STBUtil.getDirectBlockFaces()) {
             Block b = fabricationBlock.getRelative(face);
 
-            if (VanillaInventoryUtils.isVanillaInventory(b) && SensibleToolbox.getProtectionManager().hasPermission(player, b, ProtectableAction.INTERACT_BLOCK)) {
+            if (VanillaInventoryUtils.isVanillaInventory(b) && SensibleToolbox.getProtectionManager().hasPermission(player, b, Interaction.INTERACT_BLOCK)) {
                 Optional<InventoryHolder> holder = VanillaInventoryUtils.getVanillaInventory(b).map(Inventory::getHolder);
 
                 if (holder.isPresent()) {
@@ -573,7 +573,7 @@ public class RecipeBook extends BaseSTBItem {
                 if (inv != null) {
                     vanillaInventories.add(inv);
                 }
-            } else if (h instanceof BlockState && SensibleToolbox.getProtectionManager().hasPermission(player, ((BlockState) h).getBlock(), ProtectableAction.INTERACT_BLOCK)) {
+            } else if (h instanceof BlockState && SensibleToolbox.getProtectionManager().hasPermission(player, ((BlockState) h).getBlock(), Interaction.INTERACT_BLOCK)) {
                 vanillaInventories.add(h.getInventory());
             }
         }

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/recipebook/StackComparator.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/recipebook/StackComparator.java
@@ -5,7 +5,7 @@ import java.util.Comparator;
 import org.bukkit.ChatColor;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.ItemUtils;
 
 class StackComparator implements Comparator<ItemStack> {
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/slimefun/STBSlimefunGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/slimefun/STBSlimefunGenerator.java
@@ -6,18 +6,18 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.bukkit.inventory.ItemStack;
 
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
-import me.mrCookieSlime.Slimefun.Lists.RecipeType;
-import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class STBSlimefunGenerator extends STBSlimefunItem implements RecipeDisplayItem {
 
     private final List<ItemStack> fuel;
 
     @ParametersAreNonnullByDefault
-    public STBSlimefunGenerator(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, List<ItemStack> fuel) {
-        super(category, item, recipeType, recipe);
+    public STBSlimefunGenerator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, List<ItemStack> fuel) {
+        super(itemGroup, item, recipeType, recipe);
 
         this.fuel = fuel;
     }

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/slimefun/STBSlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/slimefun/STBSlimefunItem.java
@@ -4,18 +4,18 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.bukkit.inventory.ItemStack;
 
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotConfigurable;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
-import me.mrCookieSlime.Slimefun.Lists.RecipeType;
-import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class STBSlimefunItem extends SlimefunItem implements NotPlaceable, NotConfigurable {
 
     @ParametersAreNonnullByDefault
-    public STBSlimefunItem(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public STBSlimefunItem(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         setUseableInWorkbench(true);
     }

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/slimefun/SlimefunBridge.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/slimefun/SlimefunBridge.java
@@ -15,7 +15,6 @@ import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.sensibletoolbox.SensibleToolboxPlugin;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBItem;
 import io.github.thebusybiscuit.sensibletoolbox.api.recipes.STBFurnaceRecipe;
@@ -23,11 +22,12 @@ import io.github.thebusybiscuit.sensibletoolbox.api.recipes.SimpleCustomRecipe;
 import io.github.thebusybiscuit.sensibletoolbox.blocks.machines.Generator;
 import io.github.thebusybiscuit.sensibletoolbox.items.recipebook.RecipeBook;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
-import me.mrCookieSlime.Slimefun.Lists.RecipeType;
-import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
-import me.mrCookieSlime.Slimefun.cscorelib2.recipes.MinecraftRecipe;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.recipes.MinecraftRecipe;
 
 public final class SlimefunBridge implements SlimefunAddon {
 
@@ -36,12 +36,12 @@ public final class SlimefunBridge implements SlimefunAddon {
     public SlimefunBridge(@Nonnull SensibleToolboxPlugin plugin) {
         this.plugin = plugin;
 
-        Category items = new Category(new NamespacedKey(plugin, "items"), new CustomItem(Material.SHEARS, "&7STB - Items"));
-        Category blocks = new Category(new NamespacedKey(plugin, "blocks"), new CustomItem(Material.PURPLE_STAINED_GLASS, "&7STB - Blocks and Machines"));
+        ItemGroup items = new ItemGroup(new NamespacedKey(plugin, "items"), new CustomItemStack(Material.SHEARS, "&7STB - Items"));
+        ItemGroup blocks = new ItemGroup(new NamespacedKey(plugin, "blocks"), new CustomItemStack(Material.PURPLE_STAINED_GLASS, "&7STB - Blocks and Machines"));
 
         for (String id : SensibleToolboxPlugin.getInstance().getItemRegistry().getItemIds()) {
             BaseSTBItem item = SensibleToolboxPlugin.getInstance().getItemRegistry().getItemById(id);
-            Category category = item.toItemStack().getType().isBlock() ? blocks : items;
+            ItemGroup category = item.toItemStack().getType().isBlock() ? blocks : items;
             List<ItemStack> recipe = new ArrayList<>();
             RecipeType recipeType = RecipeType.NULL;
             Recipe r = item.getRecipe();
@@ -117,15 +117,15 @@ public final class SlimefunBridge implements SlimefunAddon {
             sfItem.register(this);
         }
 
-        RecipeType masher = new RecipeType(new NamespacedKey(plugin, "masher"), SlimefunItem.getByID("STB_MASHER").getItem());
-        RecipeType fermenter = new RecipeType(new NamespacedKey(plugin, "fermenter"), SlimefunItem.getByID("STB_FERMENTER").getItem());
-        RecipeType mobDrop = new RecipeType(new NamespacedKey(plugin, "mob_drop"), new CustomItem(Material.IRON_SWORD, "&bMob Drop", "&7Kill that Mob to", "&7obtain this Item"));
+        RecipeType masher = new RecipeType(new NamespacedKey(plugin, "masher"), SlimefunItem.getById("STB_MASHER").getItem());
+        RecipeType fermenter = new RecipeType(new NamespacedKey(plugin, "fermenter"), SlimefunItem.getById("STB_FERMENTER").getItem());
+        RecipeType mobDrop = new RecipeType(new NamespacedKey(plugin, "mob_drop"), new CustomItemStack(Material.IRON_SWORD, "&bMob Drop", "&7Kill that Mob to", "&7obtain this Item"));
 
-        patch("STB_INFERNALDUST", mobDrop, new CustomItem(Material.BLAZE_SPAWN_EGG, "&a&oBlaze"));
-        patch("STB_ENERGIZEDGOLDINGOT", new RecipeType(MinecraftRecipe.FURNACE), SlimefunItem.getByID("STB_ENERGIZEDGOLDDUST").getItem());
+        patch("STB_INFERNALDUST", mobDrop, new CustomItemStack(Material.BLAZE_SPAWN_EGG, "&a&oBlaze"));
+        patch("STB_ENERGIZEDGOLDINGOT", new RecipeType(MinecraftRecipe.FURNACE), SlimefunItem.getById("STB_ENERGIZEDGOLDDUST").getItem());
         patch("STB_QUARTZDUST", masher, new ItemStack(Material.QUARTZ));
-        patch("STB_ENERGIZEDIRONINGOT", new RecipeType(MinecraftRecipe.FURNACE), SlimefunItem.getByID("STB_ENERGIZEDIRONDUST").getItem());
-        patch("STB_SILICONWAFER", new RecipeType(MinecraftRecipe.FURNACE), SlimefunItem.getByID("STB_QUARTZDUST").getItem());
+        patch("STB_ENERGIZEDIRONINGOT", new RecipeType(MinecraftRecipe.FURNACE), SlimefunItem.getById("STB_ENERGIZEDIRONDUST").getItem());
+        patch("STB_SILICONWAFER", new RecipeType(MinecraftRecipe.FURNACE), SlimefunItem.getById("STB_QUARTZDUST").getItem());
         patch("STB_IRONDUST", masher, new ItemStack(Material.IRON_INGOT));
         patch("STB_GOLDDUST", masher, new ItemStack(Material.GOLD_INGOT));
         patch("STB_FISHBAIT", fermenter, new ItemStack(Material.ROTTEN_FLESH));
@@ -133,7 +133,7 @@ public final class SlimefunBridge implements SlimefunAddon {
 
     @ParametersAreNonnullByDefault
     private void patch(String id, RecipeType recipeType, ItemStack recipe) {
-        SlimefunItem item = SlimefunItem.getByID(id);
+        SlimefunItem item = SlimefunItem.getById(id);
 
         if (item != null) {
             item.setRecipe(new ItemStack[] { null, null, null, null, recipe, null, null, null, null });

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
@@ -4,8 +4,10 @@ import java.util.Optional;
 
 import org.bukkit.Material;
 
+import lombok.NonNull;
+
 public final class MaterialConverter {
-	public static Optional<Material> getSaplingFromLog(Material log) {
+	public static Optional<Material> getSaplingFromLog(@NonNull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
 
@@ -18,7 +20,7 @@ public final class MaterialConverter {
 		}
 	}
 
-	public static Optional<Material> getPlanksFromLog(Material log) {
+	public static Optional<Material> getPlanksFromLog(@NonNull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
 
@@ -31,7 +33,7 @@ public final class MaterialConverter {
 		}
 	}
 
-	public static boolean isLog(Material log) {
+	public static boolean isLog(@NonNull Material log) {
 		return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
 	}
 }

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
@@ -1,0 +1,37 @@
+package io.github.thebusybiscuit.sensibletoolbox.utils;
+
+import java.util.Optional;
+
+import org.bukkit.Material;
+
+public final class MaterialConverter {
+	public static Optional<Material> getSaplingFromLog(Material log) {
+		if (!isLog(log))
+			return Optional.empty();
+
+		String type = log.name().substring(0, log.name().lastIndexOf('_'));
+		type = type.replace("STRIPPED_", "");
+		try {
+			return Optional.ofNullable(Material.valueOf(type + "_SAPLING"));
+		} catch (IllegalArgumentException ignored) {
+			return Optional.empty();
+		}
+	}
+
+	public static Optional<Material> getPlanksFromLog(Material log) {
+		if (!isLog(log))
+			return Optional.empty();
+
+		String type = log.name().substring(0, log.name().lastIndexOf('_'));
+		type = type.replace("STRIPPED_", "");
+		try {
+			return Optional.ofNullable(Material.valueOf(type + "_PLANKS"));
+		} catch (IllegalArgumentException ignored) {
+			return Optional.empty();
+		}
+	}
+
+	public static boolean isLog(Material log) {
+		return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
+	}
+}

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
@@ -10,51 +10,51 @@ import org.bukkit.Material;
  * A collection of miscellaneous material-related utility methods.
  */
 public final class MaterialConverter {
-	/**
-	 * Turn log into sapling preserving tree type
-	 *
-	 * @param log log you want to turn into sapling
-	 * @return sapling
-	 */
-	public static Optional<Material> getSaplingFromLog(@Nonnull Material log) {
-		if (!isLog(log))
-			return Optional.empty();
+    /**
+     * Turn log into sapling preserving tree type
+     *
+     * @param log log you want to turn into sapling
+     * @return sapling
+     */
+    public static Optional<Material> getSaplingFromLog(@Nonnull Material log) {
+        if (!isLog(log))
+            return Optional.empty();
 
-		String type = log.name().substring(0, log.name().lastIndexOf('_'));
-		type = type.replace("STRIPPED_", "");
-		try {
-			return Optional.ofNullable(Material.valueOf(type + "_SAPLING"));
-		} catch (IllegalArgumentException ignored) {
-			return Optional.empty();
-		}
-	}
+        String type = log.name().substring(0, log.name().lastIndexOf('_'));
+        type = type.replace("STRIPPED_", "");
+        try {
+            return Optional.ofNullable(Material.valueOf(type + "_SAPLING"));
+        } catch (IllegalArgumentException ignored) {
+            return Optional.empty();
+        }
+    }
 
-	/**
-	 * Turn log into planks preserving tree type
-	 *
-	 * @param log log you want to turn into planks
-	 * @return planks
-	 */
-	public static Optional<Material> getPlanksFromLog(@Nonnull Material log) {
-		if (!isLog(log))
-			return Optional.empty();
+    /**
+     * Turn log into planks preserving tree type
+     *
+     * @param log log you want to turn into planks
+     * @return planks
+     */
+    public static Optional<Material> getPlanksFromLog(@Nonnull Material log) {
+        if (!isLog(log))
+            return Optional.empty();
 
-		String type = log.name().substring(0, log.name().lastIndexOf('_'));
-		type = type.replace("STRIPPED_", "");
-		try {
-			return Optional.ofNullable(Material.valueOf(type + "_PLANKS"));
-		} catch (IllegalArgumentException ignored) {
-			return Optional.empty();
-		}
-	}
+        String type = log.name().substring(0, log.name().lastIndexOf('_'));
+        type = type.replace("STRIPPED_", "");
+        try {
+            return Optional.ofNullable(Material.valueOf(type + "_PLANKS"));
+        } catch (IllegalArgumentException ignored) {
+            return Optional.empty();
+        }
+    }
 
-	/**
-	 * Check if material is log (any type)
-	 *
-	 * @param log the material to check
-	 * @return true if the stack is log; false otherwise
-	 */
-	public static boolean isLog(@Nonnull Material log) {
-		return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
-	}
+    /**
+     * Check if material is log (any type)
+     *
+     * @param log the material to check
+     * @return true if the stack is log; false otherwise
+     */
+    public static boolean isLog(@Nonnull Material log) {
+        return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
+    }
 }

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
@@ -6,14 +6,16 @@ import org.bukkit.Material;
 
 import lombok.NonNull;
 
+/**
+ * A collection of miscellaneous material-related utility methods.
+ */
 public final class MaterialConverter {
 	/**
-     * Turn log into sapling preserving tree type
-     *
-     * @param log
-     *           log  you want to turn into sapling
-     * @return sapling
-     */
+	 * Turn log into sapling preserving tree type
+	 *
+	 * @param log log you want to turn into sapling
+	 * @return sapling
+	 */
 	public static Optional<Material> getSaplingFromLog(@NonNull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
@@ -26,13 +28,13 @@ public final class MaterialConverter {
 			return Optional.empty();
 		}
 	}
+
 	/**
-     * Turn log into planks preserving tree type
-     *
-     * @param log
-     *           log you want to turn into planks
-     * @return planks
-     */
+	 * Turn log into planks preserving tree type
+	 *
+	 * @param log log you want to turn into planks
+	 * @return planks
+	 */
 	public static Optional<Material> getPlanksFromLog(@NonNull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
@@ -45,13 +47,13 @@ public final class MaterialConverter {
 			return Optional.empty();
 		}
 	}
+
 	/**
-     * Check if material is log (any type)
-     *
-     * @param log
-     *            the material to check
-     * @return true if the stack is log; false otherwise
-     */
+	 * Check if material is log (any type)
+	 *
+	 * @param log the material to check
+	 * @return true if the stack is log; false otherwise
+	 */
 	public static boolean isLog(@NonNull Material log) {
 		return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
 	}

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
@@ -7,6 +7,13 @@ import org.bukkit.Material;
 import lombok.NonNull;
 
 public final class MaterialConverter {
+	/**
+     * Turn log into sapling preserving tree type
+     *
+     * @param log
+     *           log  you want to turn into sapling
+     * @return sapling
+     */
 	public static Optional<Material> getSaplingFromLog(@NonNull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
@@ -19,7 +26,13 @@ public final class MaterialConverter {
 			return Optional.empty();
 		}
 	}
-
+	/**
+     * Turn log into planks preserving tree type
+     *
+     * @param log
+     *           log you want to turn into planks
+     * @return planks
+     */
 	public static Optional<Material> getPlanksFromLog(@NonNull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
@@ -32,7 +45,13 @@ public final class MaterialConverter {
 			return Optional.empty();
 		}
 	}
-
+	/**
+     * Check if material is log (any type)
+     *
+     * @param log
+     *            the material to check
+     * @return true if the stack is log; false otherwise
+     */
 	public static boolean isLog(@NonNull Material log) {
 		return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
 	}

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
@@ -2,9 +2,9 @@ package io.github.thebusybiscuit.sensibletoolbox.utils;
 
 import java.util.Optional;
 
-import org.bukkit.Material;
+import javax.annotation.Nonnull;
 
-import lombok.NonNull;
+import org.bukkit.Material;
 
 /**
  * A collection of miscellaneous material-related utility methods.
@@ -16,7 +16,7 @@ public final class MaterialConverter {
 	 * @param log log you want to turn into sapling
 	 * @return sapling
 	 */
-	public static Optional<Material> getSaplingFromLog(@NonNull Material log) {
+	public static Optional<Material> getSaplingFromLog(@Nonnull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
 
@@ -35,7 +35,7 @@ public final class MaterialConverter {
 	 * @param log log you want to turn into planks
 	 * @return planks
 	 */
-	public static Optional<Material> getPlanksFromLog(@NonNull Material log) {
+	public static Optional<Material> getPlanksFromLog(@Nonnull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
 
@@ -54,7 +54,7 @@ public final class MaterialConverter {
 	 * @param log the material to check
 	 * @return true if the stack is log; false otherwise
 	 */
-	public static boolean isLog(@NonNull Material log) {
+	public static boolean isLog(@Nonnull Material log) {
 		return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
 	}
 }

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/STBUtil.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/STBUtil.java
@@ -33,11 +33,11 @@ import org.bukkit.metadata.Metadatable;
 
 import com.google.common.base.Joiner;
 
-import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import io.github.thebusybiscuit.sensibletoolbox.SensibleToolboxPlugin;
 import io.github.thebusybiscuit.sensibletoolbox.api.MinecraftVersion;
 import io.github.thebusybiscuit.sensibletoolbox.api.energy.Chargeable;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBItem;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.ItemUtils;
 import me.desht.dhutils.DHUtilsException;
 import me.desht.dhutils.MiscUtil;
 import me.desht.dhutils.blocks.BlockUtil;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/VanillaInventoryUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/VanillaInventoryUtils.java
@@ -20,9 +20,9 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.filters.Filter;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import me.desht.dhutils.Debugger;
 
 /**
@@ -80,7 +80,7 @@ public final class VanillaInventoryUtils {
             return 0;
         }
 
-        if (inserterId == null || !SensibleToolbox.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(inserterId), target, ProtectableAction.INTERACT_BLOCK)) {
+        if (inserterId == null || !SensibleToolbox.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(inserterId), target, Interaction.INTERACT_BLOCK)) {
             return 0;
         }
 
@@ -176,7 +176,7 @@ public final class VanillaInventoryUtils {
      */
     @Nullable
     public static ItemStack pullFromInventory(Block target, int amount, ItemStack buffer, Filter filter, @Nullable UUID pullerId) {
-        if (pullerId == null || !SensibleToolbox.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(pullerId), target, ProtectableAction.INTERACT_BLOCK)) {
+        if (pullerId == null || !SensibleToolbox.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(pullerId), target, Interaction.INTERACT_BLOCK)) {
             return null;
         }
 


### PR DESCRIPTION
## Description
Fixed things to match the API changes in RC-27/28. (md5sha256 fork)
Latest release of SF is missing MaterialConverter (I think somebody is cleaning up the CSCoreLib mess).
So basing on decompiled RC25 and latest CSCoreLib I have created MaterialConverter class inside STB utils package.

## Changes
1. Tuned things to match the API changes in RC-27.
2. Restored and adapted MaterialConverter

## Related Issues
#103 in BusyBiscuit's fork.

## Checklist
- [ ok] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ok ] I followed the existing code standards and didn't mess up the formatting.
- [ ok] I did my best to add documentation to any public classes or methods I added.
- [ok ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values

Im using this build on my public mc server, everything is working properly.
