### PR TITLE
fix for I.R modules dupe

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/DirectionalItemRouterModule.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/DirectionalItemRouterModule.java
@@ -227,16 +227,18 @@ public abstract class DirectionalItemRouterModule extends ItemRouterModule imple
     }
 
     @Override
-    public boolean onSlotClick(HumanEntity player, int slot, ClickType click, ItemStack inSlot, ItemStack onCursor) {
-        if (onCursor.getType() == Material.AIR) {
-            gui.getInventory().setItem(slot, null);
-        } else {
-            ItemStack stack = onCursor.clone();
-            stack.setAmount(1);
-            gui.getInventory().setItem(slot, stack);
-        }
-        return false;
+    public boolean onSlotClick() {
+        return null;
     }
+
+
+
+
+
+
+
+
+
 
     @Override
     public boolean onPlayerInventoryClick(HumanEntity player, int slot, ClickType click, ItemStack inSlot, ItemStack onCursor) {

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/DirectionalItemRouterModule.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/DirectionalItemRouterModule.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.sensibletoolbox.items.itemroutermodules;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -17,6 +18,7 @@ import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.material.Directional;
 
 import io.github.bakedlibs.dough.items.ItemUtils;
@@ -36,6 +38,8 @@ import io.github.thebusybiscuit.sensibletoolbox.blocks.router.ItemRouter;
 import io.github.thebusybiscuit.sensibletoolbox.utils.UnicodeSymbol;
 import io.github.thebusybiscuit.sensibletoolbox.utils.VanillaInventoryUtils;
 
+import javax.annotation.Nullable;
+
 public abstract class DirectionalItemRouterModule extends ItemRouterModule implements Filtering, Directional {
 
     private static final String LIST_ITEM = ChatColor.LIGHT_PURPLE + UnicodeSymbol.CENTERED_POINT.toUnicode() + " " + ChatColor.AQUA;
@@ -51,6 +55,7 @@ public abstract class DirectionalItemRouterModule extends ItemRouterModule imple
     private BlockFace direction;
     private boolean terminator;
     private InventoryGUI gui;
+    private ItemStack item;
     private final int[] filterSlots = { 1, 2, 3, 10, 11, 12, 19, 20, 21 };
 
     /**
@@ -224,6 +229,30 @@ public abstract class DirectionalItemRouterModule extends ItemRouterModule imple
         newLore[lore.length] = "L-click Block: " + ChatColor.WHITE + " Set direction";
         newLore[lore.length + 1] = UnicodeSymbol.ARROW_UP.toUnicode() + " + L-click Air: " + ChatColor.WHITE + " Unset direction";
         return newLore;
+    }
+
+    @Override
+    public boolean onSlotClick(HumanEntity player, int slot, ClickType click, ItemStack inSlot, ItemStack onCursor) {
+        if (onCursor.getType() == Material.AIR) {
+            gui.getInventory().setItem(slot, null);
+        } else {
+            ItemStack item = onCursor.clone();
+            ItemMeta meta = item.getItemMeta();
+            List<String> lore = new ArrayList<>();
+
+            if (meta != null) {
+                List<String> currentLore = meta.getLore();
+                if (currentLore != null) {lore.addAll(currentLore);}
+            }
+
+            lore.add(ChatColor.DARK_GRAY + "Filtered Item");
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+
+            item.setAmount(1);
+            gui.getInventory().setItem(slot,item);
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/DirectionalItemRouterModule.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/DirectionalItemRouterModule.java
@@ -231,15 +231,6 @@ public abstract class DirectionalItemRouterModule extends ItemRouterModule imple
         return null;
     }
 
-
-
-
-
-
-
-
-
-
     @Override
     public boolean onPlayerInventoryClick(HumanEntity player, int slot, ClickType click, ItemStack inSlot, ItemStack onCursor) {
         return true;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/DirectionalItemRouterModule.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/DirectionalItemRouterModule.java
@@ -55,7 +55,6 @@ public abstract class DirectionalItemRouterModule extends ItemRouterModule imple
     private BlockFace direction;
     private boolean terminator;
     private InventoryGUI gui;
-    private ItemStack item;
     private final int[] filterSlots = { 1, 2, 3, 10, 11, 12, 19, 20, 21 };
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/DirectionalItemRouterModule.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/DirectionalItemRouterModule.java
@@ -227,11 +227,6 @@ public abstract class DirectionalItemRouterModule extends ItemRouterModule imple
     }
 
     @Override
-    public boolean onSlotClick() {
-        return null;
-    }
-
-    @Override
     public boolean onPlayerInventoryClick(HumanEntity player, int slot, ClickType click, ItemStack inSlot, ItemStack onCursor) {
         return true;
     }


### PR DESCRIPTION
## Description
When using router filter you can make dupes, i tried to fix that the way sf cargo filters does

## Changes
removed onSlotClick thing

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
(i didnt tested it yet since im on phone)