### PR TITLE
Update to 1.19.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- Spigot properties -->
-        <spigot.version>1.18.1</spigot.version>
+        <spigot.version>1.19.2</spigot.version>
         <spigot.javadocs>https://hub.spigotmc.org/javadocs/spigot/</spigot.javadocs>
 
         <!-- Default settings for sonarcloud.io -->
@@ -230,7 +230,7 @@
         <dependency>
             <groupId>io.github.baked-libs</groupId>
             <artifactId>dough-api</artifactId>
-            <version>1.1.1</version>
+            <version>1.2.0</version>
             <scope>compile</scope>
         </dependency>
 
@@ -244,7 +244,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>2.2.1</version>
+            <version>3.0.0</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/SensibleToolboxPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/SensibleToolboxPlugin.java
@@ -9,7 +9,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Server;
 import org.bukkit.command.Command;
@@ -250,7 +250,7 @@ public class SensibleToolboxPlugin extends JavaPlugin implements ConfigurationLi
             RecipeUtil.setupRecipes();
             RecipeBook.buildRecipes();
 
-            protectionManager = new ProtectionManager(getServer());
+            protectionManager = new ProtectionManager(instance);
         });
 
         getServer().getScheduler().runTaskTimer(this, LocationManager.getManager()::tick, 1L, 1L);

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/MinecraftVersion.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/MinecraftVersion.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.sensibletoolbox.api;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Server;
 
 import io.github.thebusybiscuit.sensibletoolbox.SensibleToolboxPlugin;
@@ -50,6 +50,8 @@ public enum MinecraftVersion {
      *
      */
     MINECRAFT_1_18(18, "1.18.x"),
+
+    MINECRAFT_1_19(19, "1.19.x"),
 
     /**
      * This constant represents an exceptional state in which we were unable

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/filters/Filter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/filters/Filter.java
@@ -1,6 +1,6 @@
 package io.github.thebusybiscuit.sensibletoolbox.api.filters;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/ChargeMeter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/ChargeMeter.java
@@ -1,6 +1,6 @@
 package io.github.thebusybiscuit.sensibletoolbox.api.gui.gadgets;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/DirectionGadget.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/DirectionGadget.java
@@ -3,7 +3,7 @@ package io.github.thebusybiscuit.sensibletoolbox.api.gui.gadgets;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/EnergyFlowGadget.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/EnergyFlowGadget.java
@@ -1,6 +1,6 @@
 package io.github.thebusybiscuit.sensibletoolbox.api.gui.gadgets;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/FilterTypeGadget.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/FilterTypeGadget.java
@@ -1,6 +1,6 @@
 package io.github.thebusybiscuit.sensibletoolbox.api.gui.gadgets;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/LightMeter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/LightMeter.java
@@ -1,6 +1,6 @@
 package io.github.thebusybiscuit.sensibletoolbox.api.gui.gadgets;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 
 import io.github.thebusybiscuit.sensibletoolbox.api.LightMeterHolder;
 import io.github.thebusybiscuit.sensibletoolbox.api.gui.InventoryGUI;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/NumericGadget.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/NumericGadget.java
@@ -1,7 +1,7 @@
 package io.github.thebusybiscuit.sensibletoolbox.api.gui.gadgets;
 
-import org.apache.commons.lang.Validate;
-import org.apache.commons.lang.math.IntRange;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.IntRange;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/ProgressMeter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/gui/gadgets/ProgressMeter.java
@@ -1,6 +1,6 @@
 package io.github.thebusybiscuit.sensibletoolbox.api.gui.gadgets;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBBlock.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
@@ -269,7 +269,7 @@ public abstract class BaseSTBBlock extends BaseSTBItem {
      * Check if this block may be interacted with by the player of the given
      * UUID, based on its current security settings. Note that no player
      * permission check is done here; see
-     * {@link BaseSTBItem#checkPlayerPermission(org.bukkit.entity.Player, me.desht.sensibletoolbox.api.items.BaseSTBItem.ItemAction)}.
+     * .
      *
      * @param uuid
      *            the UUID to check

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBItem.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBItem.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Keyed;
 import org.bukkit.Material;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/items/BaseSTBMachine.java
@@ -11,8 +11,8 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.StringUtils;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/recipes/CustomRecipeCollection.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/recipes/CustomRecipeCollection.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.inventory.ItemStack;
 
 import com.google.common.base.Joiner;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/recipes/CustomRecipeManager.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/recipes/CustomRecipeManager.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBMachine;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/recipes/SupplementaryResult.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/recipes/SupplementaryResult.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.sensibletoolbox.api.recipes;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.inventory.ItemStack;
 
 /**

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/BlockUpdateDetector.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/BlockUpdateDetector.java
@@ -1,6 +1,6 @@
 package io.github.thebusybiscuit.sensibletoolbox.blocks;
 
-import org.apache.commons.lang.math.IntRange;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.IntRange;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/Elevator.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/Elevator.java
@@ -3,7 +3,7 @@ package io.github.thebusybiscuit.sensibletoolbox.blocks;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/PaintCan.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/PaintCan.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.StringUtils;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/RedstoneClock.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/RedstoneClock.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.sensibletoolbox.blocks;
 
 import java.awt.Color;
 
-import org.apache.commons.lang.math.IntRange;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.IntRange;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/SoundMuffler.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/SoundMuffler.java
@@ -1,6 +1,6 @@
 package io.github.thebusybiscuit.sensibletoolbox.blocks;
 
-import org.apache.commons.lang.math.IntRange;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.IntRange;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoBuilder.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoBuilder.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.sensibletoolbox.blocks.machines;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.DyeColor;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/BigStorageUnit.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/BigStorageUnit.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.WordUtils;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.WordUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/commands/FriendCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/commands/FriendCommand.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/commands/GiveCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/commands/GiveCommand.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/commands/RedrawCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/commands/RedrawCommand.java
@@ -3,7 +3,7 @@ package io.github.thebusybiscuit.sensibletoolbox.commands;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.block.Block;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/commands/ShowCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/commands/ShowCommand.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/commands/UnfriendCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/commands/UnfriendCommand.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.sensibletoolbox.commands;
 
 import java.util.UUID;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/STBFriendManager.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/STBFriendManager.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import io.github.thebusybiscuit.sensibletoolbox.SensibleToolboxPlugin;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/STBItemRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/STBItemRegistry.java
@@ -13,7 +13,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Keyed;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/enderstorage/EnderStorageManager.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/enderstorage/EnderStorageManager.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/gui/STBInventoryGUI.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/gui/STBInventoryGUI.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang.Validate;
-import org.apache.commons.lang.math.IntRange;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.IntRange;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/storage/LocationManager.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/core/storage/LocationManager.java
@@ -19,7 +19,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/IntRange.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/IntRange.java
@@ -1,0 +1,34 @@
+package io.github.thebusybiscuit.sensibletoolbox.helpers;
+
+public class IntRange {
+    int minimumInteger;
+    int maximumInteger;
+
+    public IntRange(int x) {
+        this.minimumInteger = x;
+        this.maximumInteger = x;
+    }
+    public IntRange(int min, int max) {
+        this.minimumInteger = min;
+        this.maximumInteger = max;
+    }
+    public boolean containsInteger(int i) {
+        return i <= maximumInteger && i >= minimumInteger;
+    }
+
+    public int getMinimumInteger() {
+        return minimumInteger;
+    }
+
+    public void setMinimumInteger(int minimumInteger) {
+        this.minimumInteger = minimumInteger;
+    }
+
+    public int getMaximumInteger() {
+        return maximumInteger;
+    }
+
+    public void setMaximumInteger(int maximumInteger) {
+        this.maximumInteger = maximumInteger;
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/StringUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/StringUtils.java
@@ -1,7 +1,9 @@
 package io.github.thebusybiscuit.sensibletoolbox.helpers;
 
+import javax.annotation.Nonnull;
+
 public class StringUtils {
-    public static String repeat(String z, int i) {
+    public static String repeat(@Nonnull String z, int i) {
         StringBuilder sb = new StringBuilder();
         for(int a = 0; a < i; a++) {
             sb.append(z);
@@ -9,7 +11,7 @@ public class StringUtils {
         return sb.toString();
     }
 
-    public static boolean isNumeric(String s) {
+    public static boolean isNumeric(@Nonnull String s) {
         return s.matches("-?\\d+(\\.\\d+)?");
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/StringUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/StringUtils.java
@@ -1,0 +1,15 @@
+package io.github.thebusybiscuit.sensibletoolbox.helpers;
+
+public class StringUtils {
+    public static String repeat(String z, int i) {
+        StringBuilder sb = new StringBuilder();
+        for(int a = 0; a < i; a++) {
+            sb.append(z);
+        }
+        return sb.toString();
+    }
+
+    public static boolean isNumeric(String s) {
+        return s.matches("-?\\d+(\\.\\d+)?");
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/Validate.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/Validate.java
@@ -1,0 +1,34 @@
+package io.github.thebusybiscuit.sensibletoolbox.helpers;
+
+import java.io.IOException;
+
+public class Validate {
+    public static void isTrue(boolean b, String s) {
+        if(!b) {
+            throwException(new IOException(s));
+        }
+    }
+
+    public static void notNull(Object o, String s) {
+        if(o == null) {
+            throwException(new IOException(s));
+        }
+    }
+
+    public static void noNullElements(Object[] objs, String s) {
+        for(int i = 0; i < objs.length; i++) {
+            if(objs[i] == null) {
+                throwException(new IOException(s));
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> void throwException(Throwable exception, Object dummy) throws T{
+        throw (T) exception;
+    }
+
+    public static void throwException(Throwable exception) {
+        Validate.<RuntimeException>throwException(exception, null);
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/Validate.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/Validate.java
@@ -16,6 +16,9 @@ public class Validate {
     }
 
     public static void noNullElements(Object[] objs, String s) {
+        if(objs == null) {
+            throwException(new IOException("Argument is null!"));
+        }
         for(int i = 0; i < objs.length; i++) {
             if(objs[i] == null) {
                 throwException(new IOException(s));

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/WordUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/WordUtils.java
@@ -1,7 +1,9 @@
 package io.github.thebusybiscuit.sensibletoolbox.helpers;
 
+import javax.annotation.Nonnull;
+
 public class WordUtils {
-    public static String wrap(String s, int w) {
+    public static String wrap(@Nonnull String s, int w) {
         StringBuilder sb = new StringBuilder();
 
         char[] ch = s.toCharArray();

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/WordUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/helpers/WordUtils.java
@@ -1,0 +1,17 @@
+package io.github.thebusybiscuit.sensibletoolbox.helpers;
+
+public class WordUtils {
+    public static String wrap(String s, int w) {
+        StringBuilder sb = new StringBuilder();
+
+        char[] ch = s.toCharArray();
+        for(int i = 0; i < ch.length; i++) {
+            int a = i % w;
+            sb.append(ch[i]);
+            if(a == w-1) {
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/EnderTuner.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/EnderTuner.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.sensibletoolbox.items;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.math.IntRange;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.IntRange;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/listeners/GeneralListener.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/listeners/GeneralListener.java
@@ -3,7 +3,7 @@ package io.github.thebusybiscuit.sensibletoolbox.listeners;
 import java.util.Iterator;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/BukkitSerialization.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/BukkitSerialization.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/ColoredMaterial.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/ColoredMaterial.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/STBUtil.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/STBUtil.java
@@ -13,8 +13,8 @@ import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.StringUtils;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.DyeColor;

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/VanillaInventoryUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/VanillaInventoryUtils.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.math.IntRange;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.IntRange;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;

--- a/src/main/java/me/desht/dhutils/blocks/RelativePosition.java
+++ b/src/main/java/me/desht/dhutils/blocks/RelativePosition.java
@@ -1,6 +1,6 @@
 package me.desht.dhutils.blocks;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBBlock;
 

--- a/src/main/java/me/desht/dhutils/commands/AbstractCommand.java
+++ b/src/main/java/me/desht/dhutils/commands/AbstractCommand.java
@@ -12,8 +12,8 @@ import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.StringUtils;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;

--- a/src/main/java/me/desht/dhutils/commands/CommandManager.java
+++ b/src/main/java/me/desht/dhutils/commands/CommandManager.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import io.github.thebusybiscuit.sensibletoolbox.helpers.Validate;
 import org.bukkit.Sound;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;


### PR DESCRIPTION
## Description
ye ye, I saw the other pr, but it was too late, I was already done ;p
stb stopped working in 1.19.x because of removed dependency (apache commons-lang).
I was bored so i did some boilerplating and recreated all apache.lang methods used in plugin and put them into `helpers` package, inclucing these nasty Validator class.
everyting is working, using it on my public server.

## Changes
redirected apache.commons.lang imports to classes inside helpers package
changed protection manager argument to instance of the plugin

## Related Issues
(n/d)

## Checklist
- [y] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [y] I followed the existing code standards and didn't mess up the formatting.
- [y] I did my best to add documentation to any public classes or methods I added.
- [y] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
